### PR TITLE
feat(domain): add inbound use case ports and PlayerRepositoryPort

### DIFF
--- a/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/CreatePlayerUseCase.java
+++ b/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/CreatePlayerUseCase.java
@@ -1,0 +1,8 @@
+package com.blackjack.player.domain.port.in;
+
+import com.blackjack.player.domain.model.Player;
+import reactor.core.publisher.Mono;
+
+public interface CreatePlayerUseCase {
+    Mono<Player> execute(String name);
+}

--- a/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/DeletePlayerUseCase.java
+++ b/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/DeletePlayerUseCase.java
@@ -1,0 +1,7 @@
+package com.blackjack.player.domain.port.in;
+
+import reactor.core.publisher.Mono;
+
+public interface DeletePlayerUseCase {
+    Mono<Void> execute(String playerId);
+}

--- a/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/GetPlayerUseCase.java
+++ b/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/GetPlayerUseCase.java
@@ -1,0 +1,8 @@
+package com.blackjack.player.domain.port.in;
+
+import com.blackjack.player.domain.model.Player;
+import reactor.core.publisher.Mono;
+
+public interface GetPlayerUseCase {
+    Mono<Player> execute(String playerId);
+}

--- a/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/UpdatePlayerNameUseCase.java
+++ b/blackjack-api/src/main/java/com/blackjack/player/domain/port/in/UpdatePlayerNameUseCase.java
@@ -1,0 +1,7 @@
+package com.blackjack.player.domain.port.in;
+
+import reactor.core.publisher.Mono;
+
+public interface UpdatePlayerNameUseCase {
+    Mono<Void> execute(String playerId, String newName);
+}

--- a/blackjack-api/src/main/java/com/blackjack/player/domain/port/out/PlayerRepositoryPort.java
+++ b/blackjack-api/src/main/java/com/blackjack/player/domain/port/out/PlayerRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.blackjack.player.domain.port.out;
+
+import com.blackjack.player.domain.model.Player;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface PlayerRepositoryPort {
+    Mono<Player> save(Player player);
+
+    Mono<Player> findById(String playerId);
+
+    Flux<Player> findAll();
+
+    Mono<Void> deleteById(String playerId);
+}


### PR DESCRIPTION
- Define 4 inbound use case interfaces for player operations:
  * CreatePlayerUseCase: Mono<Player>
  * GetPlayerUseCase: Mono<Player>
  * UpdatePlayerNameUseCase: Mono<Void>
  * DeletePlayerUseCase: Mono<Void>
- Add PlayerRepositoryPort for outbound persistence operations:
  * save, findById, findAll, deleteById (Mono/Flux).
- Remove placeholder `.gitkeep` file.

close #33 